### PR TITLE
new module option value from TypeScript4.5

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -15,6 +15,7 @@ declare namespace TsConfigJson {
 			| 'ES6'
 			| 'ES2015'
 			| 'ES2020'
+			| 'ES2022'
 			| 'ESNext'
 			| 'None'
 			// Lowercase alternatives
@@ -25,6 +26,7 @@ declare namespace TsConfigJson {
 			| 'es6'
 			| 'es2015'
 			| 'es2020'
+			| 'es2022'
 			| 'esnext'
 			| 'none';
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Add `--module: es2022` from [TypeScript 4.5](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#module-es2022) to tsconfig typing.
